### PR TITLE
Set initial favorite apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ show-config: dev-deps ## Show current configuration
 
 run: syntax collections ## Run setup using current configuration selections
 	@echo "Running setup with current configuration..."
-	@$(PYTHON) -c "import yaml; config=yaml.safe_load(open('config.yml')); tags=[k.replace('_', '-') for k,v in config.items() if v and k not in ['component_descriptions', 'default_selections']]; print('ansible-playbook -i $(INVENTORY) -c $(CONNECTION) $(PLAYBOOK) -v --ask-become-pass ' + ('--tags ' + ','.join(tags) if tags else ''))" | bash
+	@$(PYTHON) -c "import yaml; config=yaml.safe_load(open('config.yml')); tags=[k.replace('_', '-') for k,v in config.items() if v and k not in ['component_descriptions', 'default_selections']]; print('ansible-playbook -i $(INVENTORY) -c $(CONNECTION) $(PLAYBOOK) --ask-become-pass ' + ('--tags ' + ','.join(tags) if tags else ''))" | bash
 
 dev-deps: ## Install development/test dependencies (e.g., ansible-lint) in venv
 	@echo "Setting up Python virtual environment at $(VENV_DIR)..."

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -159,3 +159,8 @@ claude_code_install_method: "native"  # Options: native
 claude_code_version: "stable"
 # Control auto-updates. If false, we disable via config and env during install
 claude_code_auto_updates: true
+
+# GNOME favorites (dash) configuration
+gnome_favorite_apps:
+  - org.mozilla.firefox.desktop
+  - org.gnome.Ptyxis.desktop

--- a/ansible/roles/gnome_extensions/tasks/main.yml
+++ b/ansible/roles/gnome_extensions/tasks/main.yml
@@ -30,7 +30,7 @@
       - "--id"
       - "{{ item.pk | default(item.id) }}"
       - "--enable-after-install"
-      - "{{ (gnome_extensions_enable_after_install | default(false)) | ternary('true','false') }}"
+      - "{{ (gnome_extensions_enable_after_install | default(false)) | ternary('true', 'false') }}"
   register: gnome_extensions_install_outcomes
   changed_when: "'\"installed_now\": true' in (gnome_extensions_install_outcomes.stdout | default(''))"
   failed_when: gnome_extensions_install_outcomes.rc != 0
@@ -39,7 +39,6 @@
   loop: "{{ gnome_extensions_install_list | default([]) }}"
   loop_control:
     label: "pk={{ item.pk | default(item.id) }}"
-
 
 - name: Summary reminder (Wayland re-login)
   ansible.builtin.debug:

--- a/ansible/roles/system_config/tasks/main.yml
+++ b/ansible/roles/system_config/tasks/main.yml
@@ -108,3 +108,29 @@
   changed_when: true
   when: system_config_gnome_check.rc == 0
   failed_when: false  # Allow to fail since user settings don't require system db updates
+
+- name: Get GNOME Favorites
+  ansible.builtin.command: gsettings get org.gnome.shell favorite-apps
+  register: system_config_gnome_favorites
+  when: system_config_gnome_check.rc == 0
+  failed_when: false
+  changed_when: false
+
+- name: Build desired favorites string (GVariant syntax)
+  ansible.builtin.set_fact:
+    system_config_desired_favorites: "{{ (gnome_favorite_apps | to_json) | replace('\"', \"'\") }}"
+  when: system_config_gnome_check.rc == 0
+
+- name: Set GNOME Favorites if is defaults (Contains Calculator)
+  ansible.builtin.command:
+    argv:
+      - gsettings
+      - set
+      - org.gnome.shell
+      - favorite-apps
+      - "{{ system_config_desired_favorites }}"
+  changed_when: true
+  when:
+    - system_config_gnome_check.rc == 0
+    - system_config_gnome_favorites.stdout is defined
+    - "'Calculator' in system_config_gnome_favorites.stdout"


### PR DESCRIPTION
Searches for 'Calculator' which I never favorite.  If found, resets to just Firefox and Terminal.  Won't update it after that again unless 'Calculator' shows up again..

Assisted-by: Cursor (gpt-5)