### PR TITLE
Add Windows 11 / Git Bash compatibility improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,17 @@ LIMIT ?=
 
 # Python virtual environment
 VENV_DIR ?= .venv
-PYTHON := $(VENV_DIR)/bin/python
-PIP := $(VENV_DIR)/bin/pip
-UV := $(VENV_DIR)/bin/uv
+
+# Detect MSYS/Git Bash on Windows (Scripts vs bin)
+ifdef MSYSTEM
+  PYTHON := $(VENV_DIR)/Scripts/python
+  PIP := $(VENV_DIR)/Scripts/pip
+  UV := $(VENV_DIR)/Scripts/uv
+else
+  PYTHON := $(VENV_DIR)/bin/python
+  PIP := $(VENV_DIR)/bin/pip
+  UV := $(VENV_DIR)/bin/uv
+endif
 
 # Project-local Ansible collections location
 COLLECTIONS_DIR := $(CURDIR)/collections
@@ -35,7 +43,11 @@ YELLOW := \033[33m
 RESET := \033[0m
 
 # Export common environment for all recipes
-export PATH := $(CURDIR)/$(VENV_DIR)/bin:$(PATH)
+ifdef MSYSTEM
+  export PATH := $(CURDIR)/$(VENV_DIR)/Scripts:$(PATH)
+else
+  export PATH := $(CURDIR)/$(VENV_DIR)/bin:$(PATH)
+endif
 export ANSIBLE_CONFIG := $(CURDIR)/$(ANSIBLE_DIR)/ansible.cfg
 export ANSIBLE_COLLECTIONS_PATH := $(COLLECTIONS_DIR)
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,69 @@ See `VM-Management.md` for detailed SPICE tunneling setup.
 
 **Note**: The share uses PAM authentication, so use your system username and password when prompted.
 
+## Windows 11 Compatibility
+
+This project is designed for Red Hat family Linux distributions (Fedora, RHEL, CentOS). The Ansible playbook **cannot run on Windows** -- Ansible does not support Windows as a local control node, and the playbook uses Linux-specific modules (`dnf`, `systemd`, `firewalld`, SELinux, GNOME/dconf).
+
+However, several pieces of this project can be reused on Windows 11 with Git Bash.
+
+### What works on Windows 11 + Git Bash
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| **Dotfiles** (.bashrc, .bashrc.d/*) | Works | Sourced by Git Bash automatically if placed in `$HOME` |
+| **Git configuration** (aliases, colors) | Works | Run `git config` commands manually or via a script |
+| **bin/remote-add** | Works | Uses git commands available in Git Bash |
+| **bin/trim** | Works | Uses sed, available in Git Bash |
+| **configure.py / make configure** | Works | Requires Python 3 and `make` (install via `choco install make`) |
+| **make lint** | Works | Requires Python 3 in PATH |
+| **Cursor IDE** | Works | Install Cursor for Windows directly from cursor.com |
+| **Claude Code** | Works | Install via `npm install -g @anthropic-ai/claude-code` on Windows |
+
+### What does NOT work on Windows 11
+
+| Component | Reason |
+|-----------|--------|
+| **make run** (Ansible playbook) | Ansible requires Linux; uses dnf, systemd, firewalld |
+| **packages role** | Uses `dnf` package manager (Fedora/RHEL only) |
+| **system_config role** | GNOME desktop, dconf, gsettings are Linux-only |
+| **gnome_extensions role** | GNOME Shell is Linux-only |
+| **ssh role** | Uses systemd and firewalld for service management |
+| **nomachine role** | Downloads Linux RPM; use NoMachine Windows installer instead |
+| **samba role** | SELinux contexts, systemd services; Windows has native SMB |
+| **ntpd role** | Linux NTP daemon; Windows uses Windows Time Service |
+| **screen/screenrc** | GNU Screen is not available in Git Bash |
+| **bin/samba-password** | Requires smbpasswd, pdbedit (Linux Samba tools) |
+
+### Manual setup on Windows 11 with Git Bash
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/jewzaam/workstation-setup
+cd workstation-setup
+
+# 2. Copy dotfiles to your Git Bash home directory
+cp ansible/roles/files/files/bashrc ~/.bashrc
+cp ansible/roles/files/files/vimrc ~/.vimrc
+mkdir -p ~/.bashrc.d
+cp ansible/roles/files/files/bashrc.d/* ~/.bashrc.d/
+mkdir -p ~/bin
+cp ansible/roles/files/files/bin/remote-add ~/bin/
+cp ansible/roles/files/files/bin/trim ~/bin/
+
+# 3. Apply git configuration manually
+git config --global push.default simple
+git config --global core.autocrlf true   # Note: 'true' is typical for Windows
+git config --global core.editor vim
+git config --global alias.lol 'log --graph --decorate --pretty=oneline --abbrev-commit'
+git config --global alias.lola 'log --graph --decorate --pretty=oneline --abbrev-commit --all'
+git config --global color.ui true
+git config --global pull.ff only
+git config --global init.defaultBranch main
+
+# 4. Restart Git Bash to pick up the new .bashrc
+```
+
 ## Requirements Reference
 
 **Original automation requirements:**

--- a/ansible/roles/files/files/bashrc.d/00-base
+++ b/ansible/roles/files/files/bashrc.d/00-base
@@ -2,10 +2,13 @@
 # .bashrc.d/00-base - Core system initialization
 # This file is managed by ansible - user customizations go in ~/.bashrc.d/99-user
 
-# Source global definitions
+# Source global definitions (Linux)
 if [ -f /etc/bashrc ]; then
 	. /etc/bashrc
 fi
 
 # http://unix.stackexchange.com/questions/72086/ctrl-s-hang-terminal-emulator
-stty -ixon
+# stty works in Git Bash on Windows but only when running in a real terminal
+if [ -t 0 ]; then
+    stty -ixon
+fi

--- a/ansible/roles/files/files/bashrc.d/10-exports
+++ b/ansible/roles/files/files/bashrc.d/10-exports
@@ -3,9 +3,15 @@
 # This file is managed by ansible - user customizations go in ~/.bashrc.d/99-user
 
 export HISTTIMEFORMAT="%Y/%m/%d %T "
-export GOPATH=`go env GOPATH`
-export GOROOT=`go env GOROOT`
-export PATH=~/bin:$PATH:~/Downloads/google-cloud-sdk/bin/:~/.local/bin:$GOPATH/bin
+
+# Go environment (only if go is installed)
+if command -v go >/dev/null 2>&1; then
+    export GOPATH=$(go env GOPATH)
+    export GOROOT=$(go env GOROOT)
+    export PATH=$PATH:$GOPATH/bin
+fi
+
+export PATH=~/bin:$PATH:~/.local/bin
 
 # make vi alias default editor
 export EDITOR=vi
@@ -15,8 +21,19 @@ export EDITOR=vi
 
 # set so sqldeveloper works for OCI
 export NLS_LANG=AMERICA_AMERICAN.AL32UTF8
-export JAVA_HOME=/etc/alternatives/java_sdk
+
+# Java home (Linux-specific path)
+if [ -d /etc/alternatives/java_sdk ]; then
+    export JAVA_HOME=/etc/alternatives/java_sdk
+fi
 
 export PYTHONDONTWRITEBYTECODE=1
 
-export PATH=~/.npm-global/bin:$PATH
+if [ -d ~/.npm-global/bin ]; then
+    export PATH=~/.npm-global/bin:$PATH
+fi
+
+# Google Cloud SDK (if present)
+if [ -d ~/Downloads/google-cloud-sdk/bin ]; then
+    export PATH=$PATH:~/Downloads/google-cloud-sdk/bin
+fi

--- a/ansible/roles/files/files/bashrc.d/20-aliases
+++ b/ansible/roles/files/files/bashrc.d/20-aliases
@@ -3,14 +3,18 @@
 # This file is managed by ansible - user customizations go in ~/.bashrc.d/99-user
 
 alias vi='vim -p'
-alias pjson="python -mjson.tool"
+alias pjson="python3 -mjson.tool"
 alias pxml="xmllint --format -"
-alias sjson="python -c 'import json,sys; print json.dumps(json.load(sys.stdin), sort_keys=True)'"
+alias sjson="python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin), sort_keys=True))'"
 alias psjson="sjson|pjson"
 # https://gist.github.com/mboersma/1329669
-alias y2j="python -c 'import json, sys, yaml ; y=yaml.safe_load(sys.stdin.read()) ; json.dump(y, sys.stdout)'"
-alias j2y="python -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)'"
+alias y2j="python3 -c 'import json, sys, yaml ; y=yaml.safe_load(sys.stdin.read()) ; json.dump(y, sys.stdout)'"
+alias j2y="python3 -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)'"
 alias nopush="git remote set-url --push origin no_push"
-alias oct="oc run testing --image=registry.redhat.io/rhel7/rhel-tools -i -t --rm --restart=Never -- /bin/bash"
 alias pip="pip3"
 alias fetch="git fetch --all --prune --tags"
+
+# Linux-only aliases (oc requires OpenShift CLI)
+if command -v oc >/dev/null 2>&1; then
+    alias oct="oc run testing --image=registry.redhat.io/rhel7/rhel-tools -i -t --rm --restart=Never -- /bin/bash"
+fi

--- a/make/env.mk
+++ b/make/env.mk
@@ -3,15 +3,25 @@
 
 .PHONY: venv uv pip-install-dev clean
 
+# Detect Python command (python3 on Linux/macOS, python on Windows/Git Bash)
+PYTHON3 := $(shell command -v python3 2>/dev/null || command -v python 2>/dev/null)
+
+# Detect OS for path differences (MSYS/Git Bash on Windows sets MSYSTEM)
+ifdef MSYSTEM
+  VENV_BIN := $(VENV_DIR)/Scripts
+else
+  VENV_BIN := $(VENV_DIR)/bin
+endif
+
 venv: ## Create Python virtual environment
 	@if [ ! -d "$(VENV_DIR)" ]; then \
 		printf "$(BLUE)Creating virtual environment...$(RESET)\n"; \
-		python3 -m venv $(VENV_DIR); \
+		$(PYTHON3) -m venv $(VENV_DIR); \
 		printf "$(GREEN)✅ Virtual environment created$(RESET)\n"; \
 	fi
 
 uv: venv ## Install uv package manager
-	@if [ ! -f "$(VENV_DIR)/bin/uv" ]; then \
+	@if [ ! -f "$(VENV_BIN)/uv" ] && [ ! -f "$(VENV_BIN)/uv.exe" ]; then \
 		printf "$(BLUE)Installing uv...$(RESET)\n"; \
 		$(PYTHON) -m ensurepip --upgrade; \
 		$(PYTHON) -m pip install uv; \


### PR DESCRIPTION
- Fix bashrc.d/10-exports: guard Go, Java, npm, gcloud PATH entries behind existence checks so they don't error on Windows or when tools are missing. Replace backtick command substitution with $().
- Fix bashrc.d/20-aliases: update Python 2 print syntax to Python 3, use python3 command, guard oc alias behind command check.
- Fix bashrc.d/00-base: guard stty call with terminal check (-t 0).
- Update Makefile and make/env.mk: detect MSYS/Git Bash environment to use Scripts/ instead of bin/ for venv paths, detect python vs python3 command availability.
- Add Windows 11 Compatibility section to README documenting what works in Git Bash, what doesn't, and manual setup instructions.

https://claude.ai/code/session_01BuyMf2KRWP59e8SPaWaSYx